### PR TITLE
Add particulate remineralization according to profile (e.g. Martin Curve).

### DIFF
--- a/examples/baroclinic_adjustment_with_can.jl
+++ b/examples/baroclinic_adjustment_with_can.jl
@@ -1,0 +1,291 @@
+# # Baroclinic adjustment
+#
+# In this example, we simulate the evolution and equilibration of a baroclinically
+# unstable front.
+#
+# ## Install dependencies
+#
+# First let's make sure we have all required packages installed.
+
+# ```julia
+# using Pkg
+# pkg"add Oceananigans, ClimaOceanBiogeochemistry, CairoMakie"
+# ```
+
+using Oceananigans
+using Oceananigans.Units
+using Oceananigans.TurbulenceClosures: CATKEVerticalDiffusivity
+using ClimaOceanBiogeochemistry: CarbonAlkalinityNutrients
+
+# ## Grid
+
+# We use a three-dimensional channel that is periodic in the `x` direction:
+
+Lx = 1000kilometers # east-west extent [m]
+Ly = 1000kilometers # north-south extent [m]
+Lz = 1kilometers    # depth [m]
+
+Nx = 64
+Ny = 64
+Nz = 64
+
+grid = RectilinearGrid(size = (Nx, Ny, Nz),
+                       x = (0, Lx),
+                       y = (-Ly/2, Ly/2),
+                       z = (-Lz, 0),
+                       topology = (Periodic, Bounded, Bounded))
+
+# ## Buoyancy that depends on temperature and salinity
+#
+# We use the `SeawaterBuoyancy` model with a linear equation of state,
+
+buoyancy = SeawaterBuoyancy(equation_of_state=LinearEquationOfState(thermal_expansion = 2e-4,
+                                                                    haline_contraction = 8e-4))
+
+# ## Model
+
+# We built a `HydrostaticFreeSurfaceModel` with an `ImplicitFreeSurface` solver.
+# Regarding Coriolis, we use a beta-plane centered at 45° South.
+
+model = HydrostaticFreeSurfaceModel(; grid, buoyancy,
+                                    biogeochemistry = CarbonAlkalinityNutrients(),
+                                    closure = CATKEVerticalDiffusivity(),
+                                    coriolis = BetaPlane(latitude = -45),
+                                    tracers = (:T, :S, :e),
+                                    momentum_advection = WENO(),
+                                    tracer_advection = WENO())
+
+# We want to initialize our model with a baroclinically unstable front plus some small-amplitude
+# noise.
+
+"""
+    ramp(y, Δy)
+
+Linear ramp from 0 to 1 between -Δy/2 and +Δy/2.
+
+For example:
+```
+            y < -Δy/2 => ramp = 0
+    -Δy/2 < y < -Δy/2 => ramp = y / Δy
+            y >  Δy/2 => ramp = 1
+```
+"""
+ramp(y, Δy) = min(max(0, y/Δy + 1/2), 1)
+nothing #hide
+
+# We then use `ramp(y, Δy)` to construct an initial buoyancy configuration of a baroclinically
+# unstable front. The front has a buoyancy jump `Δb` over a latitudinal width `Δy`.
+
+N² = 4e-6 # [s⁻²] buoyancy frequency / stratification
+M² = 8e-8 # [s⁻²] horizontal buoyancy gradient
+
+Δy = 50kilometers # width of the region of the front
+Δb = Δy * M²      # buoyancy jump associated with the front
+ϵb = 1e-2 * Δb    # noise amplitude
+α = buoyancy.equation_of_state.thermal_expansion
+g = buoyancy.gravitational_acceleration
+
+
+
+Tᵢ(x, y, z) = 1/(α*g) * (N² * z + Δb * ramp(y, Δy) + ϵb * randn())
+#bᵢ(x, y, z) = N² * z + Δb * ramp(y, Δy) + ϵb * randn()
+
+# BGC initial conditions
+N₀ = 16e-3 # Surface nutrient concentration
+P₀ = 1e-3 # Surface nutrient concentration
+D₀ = 0.33e-3 # Surface detritus concentration
+dᴺ = 50.0 # Nutrient mixed layer depth
+N² = 1e-5 # Buoyancy gradient, s⁻²
+
+# bᵢ(x, y, z) = N² * z
+Nᵢ(x, y, z) = N₀ * max(1, exp(-(z + dᴺ) / 100))
+Pᵢ(x, y, z) = P₀ * max(1, exp(-(z + dᴺ) / 100))
+Dᵢ(x, y, z) = D₀ * exp(z / 10)
+
+set!(model, T=Tᵢ, S=35, DIC=2.2, Alk=2.5, PO₄=Pᵢ, NO₃=Nᵢ, DOP=Dᵢ, Fe=1e-6, e=1e-6)
+
+# Now let's built a `Simulation`.
+Δt₀ = 5minutes
+stop_time = 40days
+
+simulation = Simulation(model, Δt=Δt₀, stop_time=stop_time)
+
+# We add a `TimeStepWizard` callback to adapt the simulation's time-step,
+wizard = TimeStepWizard(cfl=0.2, max_change=1.1, max_Δt=20minutes)
+simulation.callbacks[:wizard] = Callback(wizard, IterationInterval(20))
+
+# Also, we add a callback to print a message about how the simulation is going,
+using Printf
+
+wall_clock = [time_ns()]
+
+function print_progress(sim)
+    @printf("[%05.2f%%] i: %d, t: %s, wall time: %s, max(u): (%6.3e, %6.3e, %6.3e) m/s, next Δt: %s\n",
+            100 * (sim.model.clock.time / sim.stop_time),
+            sim.model.clock.iteration,
+            prettytime(sim.model.clock.time),
+            prettytime(1e-9 * (time_ns() - wall_clock[1])),
+            maximum(abs, sim.model.velocities.u),
+            maximum(abs, sim.model.velocities.v),
+            maximum(abs, sim.model.velocities.w),
+            prettytime(sim.Δt))
+
+    wall_clock[1] = time_ns()
+    
+    return nothing
+end
+
+simulation.callbacks[:print_progress] = Callback(print_progress, IterationInterval(100))
+
+# ## Diagnostics/Output
+
+# Add some diagnostics. Here, we save the buoyancy, ``b``, at the edges of our domain as well as
+# the zonal (``x``) average of buoyancy.
+
+u, v, w = model.velocities
+
+averages = NamedTuple(name => Average(model.tracers[name], dims=1) for name in keys(model.tracers))
+filename = "baroclinic_adjustment_with_can"
+save_fields_interval = 0.5day
+
+slicers = (west = (1, :, :),
+           east = (grid.Nx, :, :),
+           south = (:, 1, :),
+           north = (:, grid.Ny, :),
+           bottom = (:, :, 1),
+           top = (:, :, grid.Nz))
+
+for side in keys(slicers)
+    indices = slicers[side]
+    simulation.output_writers[side] = JLD2OutputWriter(model, model.tracers;
+                                                       filename = filename * "_$(side)_slice",
+                                                       schedule = TimeInterval(save_fields_interval),
+                                                       overwrite_existing = true,
+                                                       indices)
+end
+
+simulation.output_writers[:zonal] = JLD2OutputWriter(model, averages;
+                                                     filename = filename * "_zonal_average",
+                                                     schedule = TimeInterval(save_fields_interval),
+                                                     overwrite_existing = true)
+
+# Now let's run!
+
+@info "Running the simulation..."
+
+run!(simulation)
+
+@info "Simulation completed in " * prettytime(simulation.run_wall_time)
+
+# ## Visualization
+
+# Now we are ready to visualize our resutls! We use `CairoMakie` in this example.
+# On a system with OpenGL `using GLMakie` is more convenient as figures will be
+# displayed on the screen.
+
+using CairoMakie
+
+# We load the saved buoyancy output on the top, bottom, and east surface as `FieldTimeSeries`es.
+
+sides = keys(slicers)
+slice_filenames = NamedTuple(side => filename * "_$(side)_slice.jld2" for side in sides)
+
+b_timeserieses = (east   = FieldTimeSeries(slice_filenames.east, "PO₄"),
+                  north  = FieldTimeSeries(slice_filenames.north, "PO₄"),
+                  bottom = FieldTimeSeries(slice_filenames.bottom, "PO₄"),
+                  top    = FieldTimeSeries(slice_filenames.top, "PO₄"))
+
+avg_b_timeseries = FieldTimeSeries(filename * "_zonal_average.jld2", "PO₄")
+
+times = avg_b_timeseries.times
+
+nothing #hide
+
+# We build the coordinates. We rescale horizontal coordinates so that they correspond to kilometers.
+
+x, y, z = nodes(b_timeserieses.east)
+
+x = x .* 1e-3 # convert m -> km
+y = y .* 1e-3 # convert m -> km
+
+x_xz = repeat(x, 1, Nz)
+y_xz_north = y[end] * ones(Nx, Nz)
+z_xz = repeat(reshape(z, 1, Nz), Nx, 1)
+
+x_yz_east = x[end] * ones(Ny, Nz)
+y_yz = repeat(y, 1, Nz)
+z_yz = repeat(reshape(z, 1, Nz), grid.Ny, 1)
+
+x_xy = x
+y_xy = y
+z_xy_top = z[end] * ones(grid.Nx, grid.Ny)
+z_xy_bottom = z[1] * ones(grid.Nx, grid.Ny)
+nothing #hide
+
+# Then we create a 3D axis. We use `zonal_slice_displacement` to control where the plot of the instantaneous
+# zonal average flow is located.
+
+fig = Figure(resolution = (900, 520))
+
+zonal_slice_displacement = 1.2
+
+ax = Axis3(fig[2, 1], aspect=(1, 1, 1/5),
+           xlabel="x (km)", ylabel="y (km)", zlabel="z (m)",
+           limits = ((x[1], zonal_slice_displacement * x[end]), (y[1], y[end]), (z[1], z[end])),
+           elevation = 0.45, azimuth = 6.8,
+           xspinesvisible = false, zgridvisible=false,
+           protrusions=40,
+           perspectiveness=0.7)
+
+nothing #hide
+
+# We use Makie's `Observable` to animate the data. To dive into how `Observable`s work we
+# refer to [Makie.jl's Documentation](https://makie.juliaplots.org/stable/documentation/nodes/index.html).
+
+n = Observable(1)
+
+# Now let's make a 3D plot of the buoyancy and in front of it we'll use the zonally-averaged output
+# to plot the instantaneous zonal-average of the buoyancy.
+
+b_slices = (east   = @lift(interior(b_timeserieses.east[$n], 1, :, :)),
+            north  = @lift(interior(b_timeserieses.north[$n], :, 1, :)),
+            bottom = @lift(interior(b_timeserieses.bottom[$n], :, :, 1)),
+            top    = @lift(interior(b_timeserieses.top[$n], :, :, 1)))
+
+avg_b = @lift interior(avg_b_timeseries[$n], 1, :, :)
+
+clims = @lift 1.1 .* extrema(b_timeserieses.top[$n][:])
+
+kwargs = (colorrange = clims, colormap = :deep)
+
+surface!(ax, x_yz_east, y_yz, z_yz;    color = b_slices.east, kwargs...)
+surface!(ax, x_xz, y_xz_north, z_xz;   color = b_slices.north, kwargs...)
+surface!(ax, x_xy, y_xy, z_xy_bottom ; color = b_slices.bottom, kwargs...)
+surface!(ax, x_xy, y_xy, z_xy_top;     color = b_slices.top, kwargs...)
+
+sf = surface!(ax, zonal_slice_displacement .* x_yz_east, y_yz, z_yz; color = avg_b, kwargs...)
+
+contour!(ax, y, z, avg_b; transformation = (:yz, zonal_slice_displacement * x[end]),
+         levels = 15, linewidth = 2, color = :black)
+
+Colorbar(fig[2, 2], sf, label = "mol P m⁻³", height = 200, tellheight=false)
+
+title = @lift "Phosphate at t = " * string(round(times[$n] / day, digits=1)) * " days"
+
+fig[1, 1:2] = Label(fig, title; fontsize = 24, tellwidth = false, padding = (0, 0, -120, 0))
+
+current_figure() # hide
+fig
+
+# Finally, we add a figure title with the time of the snapshot and then record a movie.
+
+frames = 1:length(times)
+
+record(fig, filename * ".mp4", frames, framerate=8) do i
+    msg = string("Plotting frame ", i, " of ", frames[end])
+    print(msg * " \r")
+    n[] = i
+end
+nothing #hide
+
+# ![](baroclinic_adjustment.mp4)

--- a/examples/baroclinic_adjustment_with_can.jl
+++ b/examples/baroclinic_adjustment_with_can.jl
@@ -85,8 +85,6 @@ M² = 8e-8 # [s⁻²] horizontal buoyancy gradient
 #α = buoyancy.equation_of_state.thermal_expansion
 #g = buoyancy.gravitational_acceleration
 
-
-
 #Tᵢ(x, y, z) = 1/(α*g) * (N² * z + Δb * ramp(y, Δy) + ϵb * randn())
 bᵢ(x, y, z) = N² * z + Δb * ramp(y, Δy) + ϵb * randn()
 

--- a/src/carbon_alkalinity_nutrients.jl
+++ b/src/carbon_alkalinity_nutrients.jl
@@ -1,11 +1,12 @@
-using Oceananigans.Units: day
-using Oceananigans.Grids: znode, Center
-using Oceananigans.Fields: ZeroField, ConstantField
+import Oceananigans.Biogeochemistry:
+    biogeochemical_drift_velocity, required_biogeochemical_tracers
+
 using Oceananigans.Biogeochemistry: AbstractBiogeochemistry
-
-import Oceananigans.Biogeochemistry: required_biogeochemical_tracers, biogeochemical_drift_velocity
-
-const c = Center()
+using Oceananigans.Fields: ConstantField, ZeroField, FunctionField
+using Oceananigans.ImmersedBoundaries: active_cell
+using Oceananigans.Grids: Center, Face, znode
+using Oceananigans.Units: day
+using Oceananigans.AbstractOperations: ∂z
 
 """
     CarbonAlkalinityNutrients(; kw...)
@@ -32,51 +33,64 @@ Biogeochemical functions
     a constant `detritus_sinking_speed`.
 """
 struct CarbonAlkalinityNutrients{FT} <: AbstractBiogeochemistry
-    maximum_net_community_production_rate      :: FT # mol P m⁻³ s⁻¹
-    phosphate_half_saturation                  :: FT # mol P m⁻³
-    nitrate_half_saturation                    :: FT # mol N m⁻³
-    iron_half_saturation                       :: FT # mol Fe m⁻³
-    PAR_half_saturation                        :: FT  # W m⁻²
-    PAR_attenuation_scale                      :: FT  # m
-    fraction_of_particulate_export             :: FT
-    dissolved_organic_phosphate_remin_timescale:: FT # s⁻¹
-    stoichoimetric_ratio_carbon_to_phosphate   :: FT 
-    stoichoimetric_ratio_nitrate_to_phosphate  :: FT 
-    stoichoimetric_ratio_phosphate_to_oxygen   :: FT 
-    stoichoimetric_ratio_phosphate_to_iron     :: FT 
-    stoichoimetric_ratio_carbon_to_nitrate     :: FT 
-    stoichoimetric_ratio_carbon_to_oxygen      :: FT 
-    stoichoimetric_ratio_carbon_to_iron        :: FT 
-    stoichoimetric_ratio_silicate_to_phosphate :: FT 
-    rain_ratio_inorganic_to_organic_carbon     :: FT 
-    martin_curve_exponent                      :: FT 
-    iron_scavenging_rate                       :: FT # s⁻¹
-    ligand_concentration                       :: FT # mol L m⁻³
-    ligand_stability_coefficient               :: FT
+    maximum_net_community_production_rate       :: FT # mol P m⁻³ s⁻¹
+    phosphate_half_saturation                   :: FT # mol P m⁻³
+    nitrate_half_saturation                     :: FT # mol N m⁻³
+    iron_half_saturation                        :: FT # mol Fe m⁻³
+    PAR_half_saturation                         :: FT  # W m⁻²
+    PAR_attenuation_scale                       :: FT  # m
+    fraction_of_particulate_export              :: FT
+    dissolved_organic_phosphate_remin_timescale :: FT # s⁻¹
+    stoichoimetric_ratio_carbon_to_phosphate    :: FT 
+    stoichoimetric_ratio_nitrate_to_phosphate   :: FT 
+    stoichoimetric_ratio_phosphate_to_oxygen    :: FT 
+    stoichoimetric_ratio_phosphate_to_iron      :: FT 
+    stoichoimetric_ratio_carbon_to_nitrate      :: FT 
+    stoichoimetric_ratio_carbon_to_oxygen       :: FT 
+    stoichoimetric_ratio_carbon_to_iron         :: FT 
+    stoichoimetric_ratio_silicate_to_phosphate  :: FT 
+    rain_ratio_inorganic_to_organic_carbon      :: FT 
+    martin_curve_exponent                       :: FT 
+    iron_scavenging_rate                        :: FT # s⁻¹
+    ligand_concentration                        :: FT # mol L m⁻³
+    ligand_stability_coefficient                :: FT
+    particulate_organic_phosphate_remin_exponent:: FT
+    particulate_organic_phosphate_remin_curve   :: String
+    particulate_organic_phosphate_bottom_remin  :: Bool
+    particulate_inorganic_carbon_remin_exponent :: FT # s⁻¹
+    particulate_inorganic_carbon_remin_curve    :: String
+    particulate_inorganic_carbon_bottom_remin   :: Bool
 end
 
-function CarbonAlkalinityNutrients(; reference_density = 1024,
-                                   maximum_net_community_production_rate      = 1 / day, # mol P m⁻³ s⁻¹
-                                   phosphate_half_saturation                  = 1e-7 * reference_density, # mol P m⁻³
-                                   nitrate_half_saturation                    = 1.6e-6 * reference_density, # mol N m⁻³
-                                   iron_half_saturation                       = 1e-10 * reference_density, # mol Fe m⁻³
-                                   PAR_half_saturation                        = 10.0,  # W m⁻²
-                                   PAR_attenuation_scale                      = 25.0,  # m
-                                   fraction_of_particulate_export             = 0.33,
-                                   dissolved_organic_phosphate_remin_timescale= 1 / 30day, # s⁻¹
-                                   stoichoimetric_ratio_carbon_to_phosphate   = 106.0,
-                                   stoichoimetric_ratio_nitrate_to_phosphate  = 16.0,
-                                   stoichoimetric_ratio_phosphate_to_oxygen   = 170.0, 
-                                   stoichoimetric_ratio_phosphate_to_iron     = 4.68e-4,
-                                   stoichoimetric_ratio_carbon_to_nitrate     = 106 / 16,
-                                   stoichoimetric_ratio_carbon_to_oxygen      = 106 / 170, 
-                                   stoichoimetric_ratio_carbon_to_iron        = 106 / 1.e-3,
-                                   stoichoimetric_ratio_silicate_to_phosphate = 15.0,
-                                   rain_ratio_inorganic_to_organic_carbon     = 1e-1,
-                                   martin_curve_exponent                      = 0.84,
-                                   iron_scavenging_rate                       = 5e-4 / day, # s⁻¹
-                                   ligand_concentration                       = 1e-9 * reference_density, # mol L m⁻³
-                                   ligand_stability_coefficient               = 1e8)
+function CarbonAlkalinityNutrients(; reference_density                         = 1024.5, # kg m⁻³
+                                   maximum_net_community_production_rate       = 1 / day, # mol P m⁻³ s⁻¹
+                                   phosphate_half_saturation                   = 1e-7 * reference_density, # mol P m⁻³
+                                   nitrate_half_saturation                     = 1.6e-6 * reference_density, # mol N m⁻³
+                                   iron_half_saturation                        = 1e-10 * reference_density, # mol Fe m⁻³
+                                   PAR_half_saturation                         = 10.0,  # W m⁻²
+                                   PAR_attenuation_scale                       = 25.0,  # m
+                                   fraction_of_particulate_export              = 0.33,
+                                   dissolved_organic_phosphate_remin_timescale = 1 / 30day, # s⁻¹
+                                   stoichoimetric_ratio_carbon_to_phosphate    = 106.0, # mol C mol P⁻¹
+                                   stoichoimetric_ratio_nitrate_to_phosphate   = 16.0, # mol N mol P⁻¹
+                                   stoichoimetric_ratio_phosphate_to_oxygen    = 170.0, # mol P mol O⁻¹
+                                   stoichoimetric_ratio_phosphate_to_iron      = 4.68e-4, # mol P mol Fe⁻¹
+                                   stoichoimetric_ratio_carbon_to_nitrate      = 106 / 16, # mol C mol N⁻¹
+                                   stoichoimetric_ratio_carbon_to_oxygen       = 106 / 170, # mol C mol O⁻¹
+                                   stoichoimetric_ratio_carbon_to_iron         = 106 / 1.e-3, # mol C mol Fe⁻¹
+                                   stoichoimetric_ratio_silicate_to_phosphate  = 15.0, # mol Si mol P⁻¹
+                                   rain_ratio_inorganic_to_organic_carbon      = 1e-1, # mol C mol C⁻¹
+                                   martin_curve_exponent                       = 0.84, #
+                                   iron_scavenging_rate                        = 5e-4 / day, # s⁻¹
+                                   ligand_concentration                        = 1e-9 * reference_density, # mol L m⁻³
+                                   ligand_stability_coefficient                = 1e8, # s-1
+                                   particulate_organic_phosphate_remin_exponent= 0.84,
+                                   particulate_organic_phosphate_remin_curve   = "power law",
+                                   particulate_organic_phosphate_bottom_remin  = false,
+                                   particulate_inorganic_carbon_remin_exponent = 0.0,
+                                   particulate_inorganic_carbon_remin_curve    = "exponential",
+                                   particulate_inorganic_carbon_bottom_remin   = false,
+                                   )
 
     return CarbonAlkalinityNutrients(maximum_net_community_production_rate,
                                      phosphate_half_saturation,
@@ -98,36 +112,177 @@ function CarbonAlkalinityNutrients(; reference_density = 1024,
                                      martin_curve_exponent,
                                      iron_scavenging_rate,
                                      ligand_concentration,
-                                     ligand_stability_coefficient)
+                                     ligand_stability_coefficient,
+                                     particulate_organic_phosphate_remin_exponent,
+                                     particulate_organic_phosphate_remin_curve,
+                                     particulate_organic_phosphate_bottom_remin,
+                                     particulate_inorganic_carbon_remin_exponent,
+                                     particulate_inorganic_carbon_remin_curve,
+                                     particulate_inorganic_carbon_bottom_remin,
+                                     )
 end
 
 const CAN = CarbonAlkalinityNutrients
 
 @inline required_biogeochemical_tracers(::CAN) = (:DIC, :Alk, :PO₄, :NO₃, :DOP, :Fe)
 
+"""
+    net_community_production(μᵖ, kᴵ, kᴾ, kᴺ, kᶠ, I, P, N, F)
+Calculate the rate of net community production, as the 
+maximum growth rate, limited by the availability of light, phosphate, nitrate and iron.
+"""
 @inline function net_community_production(μᵖ, kᴵ, kᴾ, kᴺ, kᶠ, I, P, N, F)
-    return μᵖ * I / (I + kᴵ) * min(P / (P + kᴾ), N / (N + kᴺ), F / (F + kᶠ))
+    return μᵖ .* (I ./ (I .+ kᴵ)) .* min.(P ./ (P .+ kᴾ), N ./ (N .+ kᴺ), F ./ (F .+ kᶠ))
 end
 
+"""
+    dissolved_organic_phosphate_remin(γ, D)
+Calculate the degradation of DOP to phosphate, with remineralization rate γ.
+"""
 @inline dissolved_organic_phosphate_remin(γ, D) = γ * D
 
-# Martin Curve
-@inline particulate_organic_phosphate_remin() = 0.0
-
-# exponential remineralization or below the lysocline
-@inline particulate_inorganic_carbon_remin() = 0.0
-
-@inline air_sea_flux_co2() = 0.0
-
-@inline freshwater_virtual_flux() = 0.0
+struct ParticleReminParms{FT}
+    remin_profile_reference_depth :: FT
+    remin_profile_shape           :: String
+    remin_profile_exponent        :: FT
+end 
 
 """
-Iron scavenging should depend on free iron, involves solving a quadratic equation in terms
-of ligand concentration and stability coefficient, but this is a simple first order approximation.
+    remin_profile(x, y, z, params::ParticleReminParms)
+Calculate the remineralization profile, with parameters passed in a struct of type ParticleReminParms,
+including remin_profile_reference_depth, remin_profile_shape, (either a "power law" or an "exponential"),
+and any coefficients to the profile, such as remin_profile_exponent.
 """
-@inline iron_scavenging(kˢᶜᵃᵛ, F, Lₜ, β) = kˢᶜᵃᵛ * ( F - Lₜ )
+@inline function remin_profile(x, y, z, params::ParticleReminParms)
+    zʳᵉᶠ = params.remin_profile_reference_depth
+    ɼ    = params.remin_profile_shape
+    b    = params.remin_profile_exponent
 
-@inline iron_sources() = 0.0
+    if ɼ == "power law"
+        F = (min(z, zʳᵉᶠ) / zʳᵉᶠ)^-b
+    elseif ɼ == "exponential"
+        F = exp(-min(z, zʳᵉᶠ) / zʳᵉᶠ)
+    end
+    return F
+end
+
+"""
+   particulate_remin(i, j, k, grid, fields, λ, α, μᵖ, kᴺ, kᴾ, kᶠ, kᴵ, ɼ = "power law", b = 0.84, ⎵ = false)
+Calculate the degradation of sinking particles and return the tendency of local concentration. 
+At depth z, there will be particles that  originate from the different surface layers, and 
+remineralize according to a profile referenced to each layer. Thus we have to loop over all the 
+productive surface layers to figure out how much remineralization affects local (deep) concentrations.
+
+We can use light, depending on attenuation coefficient, λ, as a proxy otherwise would have to 
+cycle throughout the entire watercolumn.
+
+α, μᵖ, kᴺ, kᴾ, kᶠ, kᴵ relate to calculation of net community production in the productive surface layers. In
+particular, α is the portion of production that is exported as sinking particles which could be set differently
+for organic and inorganic particles such as organic carbon/phosphate or inorganic calcium carbonate.
+
+ɼ is the remineralization profile, either "power law" or "exponential", b is the exponent of the remineralization 
+profile (if it has one), and  and ⎵ ("the bottom") is a boolean that determines whether particles that reach 
+the lowest active grid cell in depth are remineralized locally, or allowed  to export nutrients and carbon
+out of the domain.
+"""
+@inline function particulate_remin(
+    i, j, k, grid, fields, λ, α, μᵖ, kᴺ, kᴾ, kᶠ, kᴵ, ɼ = "power law", b = 0.84, ⎵ = false
+    )
+
+    # Set the initial remineralization input to zero
+    dPdt = 0.0
+    
+    # Available photosynthetic radiation at each reference depth above the current depth
+    Iʳᵉᶠ = exp.(grid.zᵃᵃᶜ[k:1:grid.Nz] ./ λ)
+
+    # Get the local concentrations of the different nutrients at each reference depth
+    @inbounds Pʳᵉᶠ = fields.PO₄[i, j, k:1:grid.Nz]
+    @inbounds Nʳᵉᶠ = fields.NO₃[i, j, k:1:grid.Nz]
+    @inbounds Fʳᵉᶠ = fields.Fe[i, j, k:1:grid.Nz]
+
+    # Calculate the net community production at each reference depth above the current depth
+    PPʳᵉᶠ = α .* net_community_production(
+        μᵖ, kᴵ, kᴾ, kᴺ, kᶠ, Iʳᵉᶠ, Pʳᵉᶠ, Nʳᵉᶠ, Fʳᵉᶠ
+        )
+
+    # Loop over all layers above the current one, and determine if any particles
+    #    are produced, and if so, how much remineralization there is.
+    for (ikʳᵉᶠ,kʳᵉᶠ) ∈ enumerate(k:1:grid.Nz)
+        if PPʳᵉᶠ[ikʳᵉᶠ] > zero(1.0) # or some small number?
+        # There will be production of particles exported below this reference depth. 
+        #   Calculate  depth change in the fraction of particle remineralization 
+        #   given by the remin profile at current depth.
+            zʳᵉᶠ = znode(i, j, kʳᵉᶠ, grid, Center(), Center(), Face())
+
+            dFdz = ∂z(
+                FunctionField{Center,Center,Face}(
+                    remin_profile,
+                    grid,
+                    clock      = nothing,
+                    parameters = ParticleReminParms(zʳᵉᶠ, ɼ, b),
+                )
+            )
+
+        # ...then multiply by reference level export to calculate
+        #  change in concentration due to remineralization of particles
+            dPdt += dFdz[i, j, k] * PPʳᵉᶠ[ikʳᵉᶠ]
+        
+            if ⎵ # Flux particles from this reference depth through the bottom of the domain?
+            # find if this is the bottom-most "active" grid cell
+                if ! active_cell(i,j,k-1,grid)
+                # Integrate remin frac to find out what's left of the particles... 
+                    ∫F=Field(Integral(dFdz,dims=3))
+
+                    # ...and remineralize them here                
+                    dP_dz += (1 - ∫F[i, j]) * PPʳᵉᶠ[ikʳᵉᶠ]
+                end
+            end
+        end
+    end
+
+    # Return total amount of inorganic constituent remineralized from sinking particles
+    return dPdt
+end
+
+"""
+    air_sea_flux_co2()
+Calculate the air-sea flux of CO₂, according to the gas exchange parameterization 
+of Wanninkhof (1992).
+"""
+@inline function air_sea_flux_co2()
+    return 0.0
+end
+
+"""
+    freshwater_virtual_flux()
+Calculate the virtual flux of carbon and alkalinity, due to FW fluxes
+"""
+@inline function freshwater_virtual_flux()
+    return 0.0
+end
+
+"""
+    iron_scavenging(kˢᶜᵃᵛ, Fₜ, Lₜ, β)
+Linear loss of free iron by scavenging onto sinking particles or precipitation.
+"""
+@inline function iron_scavenging(kˢᶜᵃᵛ, Fₜ, Lₜ, β)
+       # solve for the equilibrium free iron concentration
+       β⁻¹ = 1/β
+       R₁  = 1
+       R₂  = (Lₜ + β⁻¹ - Fₜ) 
+       R₃  = -(Fₜ * β⁻¹) 
+
+       # simple quadratic solution for roots
+       discriminant = ( R₂*R₂ - ( 4*R₁*R₃ ))^(1/2)
+
+       # directly solve for the free iron concentration
+       Feᶠʳᵉᵉ = (-R₂ + discriminant) / (2*R₁) 
+
+       # return the linear scavenging rate
+       return - (kˢᶜᵃᵛ * Feᶠʳᵉᵉ)
+end
+
+@inline iron_sources() = 1e-6
 
 """
 Tracer sources and sinks for DIC
@@ -148,6 +303,12 @@ Tracer sources and sinks for DIC
     Rᶜᴼ = bgc.stoichoimetric_ratio_carbon_to_oxygen      
     Rᶜᶠ = bgc.stoichoimetric_ratio_carbon_to_iron        
     Rᶜᵃᶜᵒ³ = bgc.rain_ratio_inorganic_to_organic_carbon     
+    bᴾᴼᴾ = bgc.particulate_organic_phosphate_remin_exponent
+    ɼᴾᴼᴾ = bgc.particulate_organic_phosphate_remin_curve
+    ⎵ᴾᴼᴾ = bgc.particulate_organic_phosphate_bottom_remin
+    bᴾᴵᶜ = bgc.particulate_inorganic_carbon_remin_exponent
+    ɼᴾᴵᶜ = bgc.particulate_inorganic_carbon_remin_curve
+    ⎵ᴾᴵᶜ = bgc.particulate_inorganic_carbon_bottom_remin
 
     # Available photosynthetic radiation
     z = znode(i, j, k, grid, c, c, c)
@@ -160,8 +321,8 @@ Tracer sources and sinks for DIC
     
     return Rᶜᴾ * (dissolved_organic_phosphate_remin(γ, D) -
                  (1 + Rᶜᵃᶜᵒ³ * α) * net_community_production(μᵖ, kᴵ, kᴾ, kᴺ, kᶠ, I, P, N, F) +
-                  particulate_organic_phosphate_remin()) +
-           particulate_inorganic_carbon_remin() -
+                 particulate_remin( i, j, k, grid, fields, λ, α,            μᵖ, kᴺ, kᴾ, kᶠ, kᴵ, ɼᴾᴼᴾ, bᴾᴼᴾ, ⎵ᴾᴼᴾ)) + #POC
+                 particulate_remin( i, j, k, grid, fields, λ, Rᶜᴾ*Rᶜᵃᶜᵒ³*α, μᵖ, kᴺ, kᴾ, kᶠ, kᴵ, ɼᴾᴵᶜ, bᴾᴵᶜ, ⎵ᴾᴵᶜ) -  #PIC
            air_sea_flux_co2() -
            freshwater_virtual_flux()
 end
@@ -185,6 +346,12 @@ Tracer sources and sinks for ALK
     Rᶜᴼ = bgc.stoichoimetric_ratio_carbon_to_oxygen      
     Rᶜᶠ = bgc.stoichoimetric_ratio_carbon_to_iron        
     Rᶜᵃᶜᵒ³ = bgc.rain_ratio_inorganic_to_organic_carbon     
+    bᴾᴼᴾ = bgc.particulate_organic_phosphate_remin_exponent
+    ɼᴾᴼᴾ = bgc.particulate_organic_phosphate_remin_curve
+    ⎵ᴾᴼᴾ = bgc.particulate_organic_phosphate_bottom_remin
+    bᴾᴵᶜ = bgc.particulate_inorganic_carbon_remin_exponent
+    ɼᴾᴵᶜ = bgc.particulate_inorganic_carbon_remin_curve
+    ⎵ᴾᴵᶜ = bgc.particulate_inorganic_carbon_bottom_remin
 
     # Available photosynthetic radiation
     z = znode(i, j, k, grid, c, c, c)
@@ -198,8 +365,8 @@ Tracer sources and sinks for ALK
     return -Rᴺᴾ * (
         - (1 + Rᶜᵃᶜᵒ³ * α) * net_community_production(μᵖ, kᴵ, kᴾ, kᴺ, kᶠ, I, P, N, F) +
         dissolved_organic_phosphate_remin(γ, D) +
-        particulate_organic_phosphate_remin()) +
-        2 * particulate_inorganic_carbon_remin()
+        particulate_remin( i, j, k, grid, fields, λ, α,            μᵖ, kᴺ, kᴾ, kᶠ, kᴵ, ɼᴾᴼᴾ, bᴾᴼᴾ, ⎵ᴾᴼᴾ)) + #POC
+    2 * particulate_remin( i, j, k, grid, fields, λ, Rᶜᴾ*Rᶜᵃᶜᵒ³*α, μᵖ, kᴺ, kᴾ, kᶠ, kᴵ, ɼᴾᴵᶜ, bᴾᴵᶜ, ⎵ᴾᴵᶜ)  #PIC
 end
 
 """
@@ -221,9 +388,12 @@ Tracer sources and sinks for PO₄
     Rᶜᴼ = bgc.stoichoimetric_ratio_carbon_to_oxygen      
     Rᶜᶠ = bgc.stoichoimetric_ratio_carbon_to_iron        
     Rᶜᵃᶜᵒ³ = bgc.rain_ratio_inorganic_to_organic_carbon     
+    bᴾᴼᴾ = bgc.particulate_organic_phosphate_remin_exponent
+    ɼᴾᴼᴾ = bgc.particulate_organic_phosphate_remin_curve
+    ⎵ᴾᴼᴾ = bgc.particulate_organic_phosphate_bottom_remin
 
     # Available photosynthetic radiation
-    z = znode(i, j, k, grid, c, c, c)
+    z = znode(i, j, k, grid, Center(), Center(), Center())
     I = exp(z / λ)
 
     P = @inbounds fields.PO₄[i, j, k]
@@ -233,7 +403,7 @@ Tracer sources and sinks for PO₄
 
     return - net_community_production(μᵖ, kᴵ, kᴾ, kᴺ, kᶠ, I, P, N, F) +
            dissolved_organic_phosphate_remin(γ, D) +
-           particulate_organic_phosphate_remin()
+           particulate_remin( i, j, k, grid, fields, λ, α, μᵖ, kᴺ, kᴾ, kᶠ, kᴵ, ɼᴾᴼᴾ, bᴾᴼᴾ, ⎵ᴾᴼᴾ)
 end
 
 """
@@ -255,6 +425,9 @@ Tracer sources and sinks for NO₃
     Rᶜᴼ = bgc.stoichoimetric_ratio_carbon_to_oxygen      
     Rᶜᶠ = bgc.stoichoimetric_ratio_carbon_to_iron        
     Rᶜᵃᶜᵒ³ = bgc.rain_ratio_inorganic_to_organic_carbon     
+    bᴾᴼᴾ = bgc.particulate_organic_phosphate_remin_exponent
+    ɼᴾᴼᴾ = bgc.particulate_organic_phosphate_remin_curve
+    ⎵ᴾᴼᴾ = bgc.particulate_organic_phosphate_bottom_remin
 
     # Available photosynthetic radiation
     z = znode(i, j, k, grid, c, c, c)
@@ -268,8 +441,8 @@ Tracer sources and sinks for NO₃
     return Rᴺᴾ * (
            - net_community_production(μᵖ, kᴵ, kᴾ, kᴺ, kᶠ, I, P, N, F) +
            dissolved_organic_phosphate_remin(γ, D) +
-           particulate_organic_phosphate_remin())
-end
+           particulate_remin( i, j, k, grid, fields, λ, α, μᵖ, kᴺ, kᴾ, kᶠ, kᴵ, ɼᴾᴼᴾ, bᴾᴼᴾ, ⎵ᴾᴼᴾ)) #POP
+        end
 
 """
 Tracer sources and sinks for FeT
@@ -282,15 +455,14 @@ Tracer sources and sinks for FeT
     kᴵ = bgc.PAR_half_saturation
     λ = bgc.PAR_attenuation_scale
     γ = bgc.dissolved_organic_phosphate_remin_timescale
-    α = bgc.fraction_of_particulate_export
-    Rᶜᴾ = bgc.stoichoimetric_ratio_carbon_to_phosphate   
-    Rᴺᴾ = bgc.stoichoimetric_ratio_nitrate_to_phosphate  
-    Rᴾᴼ = bgc.stoichoimetric_ratio_phosphate_to_oxygen   
-    Rᶜᴺ = bgc.stoichoimetric_ratio_carbon_to_nitrate     
-    Rᶜᴼ = bgc.stoichoimetric_ratio_carbon_to_oxygen      
-    Rᶜᶠ = bgc.stoichoimetric_ratio_carbon_to_iron        
+    α = bgc.fraction_of_particulate_export       
     Rᶠᴾ = bgc.stoichoimetric_ratio_phosphate_to_iron
-    Rᶜᵃᶜᵒ³ = bgc.rain_ratio_inorganic_to_organic_carbon     
+    Lₜ = bgc.ligand_concentration
+    β = bgc.ligand_stability_coefficient
+    kˢᶜᵃᵛ = bgc.iron_scavenging_rate
+    bᴾᴼᴾ = bgc.particulate_organic_phosphate_remin_exponent
+    ɼᴾᴼᴾ = bgc.particulate_organic_phosphate_remin_curve
+    ⎵ᴾᴼᴾ = bgc.particulate_organic_phosphate_bottom_remin
 
     # Available photosynthetic radiation
     z = znode(i, j, k, grid, c, c, c)
@@ -303,10 +475,10 @@ Tracer sources and sinks for FeT
 
     return Rᶠᴾ * (
                 - net_community_production(μᵖ, kᴵ, kᴾ, kᴺ, kᶠ, I, P, N, F) +
-                + dissolved_organic_phosphate_remin(γ, D))
-           #    + particulate_organic_phosphate_remin()) +
-           #    + iron_sources()
-           #    - iron_scavenging())
+                 dissolved_organic_phosphate_remin(γ, D) +
+                 particulate_remin( i, j, k, grid, fields, λ, α, μᵖ, kᴺ, kᴾ, kᶠ, kᴵ, ɼᴾᴼᴾ, bᴾᴼᴾ, ⎵ᴾᴼᴾ) + #POC
+                 iron_sources() +
+                 iron_scavenging(kˢᶜᵃᵛ, F, Lₜ, β))
     end
 
 """
@@ -333,5 +505,4 @@ Tracer sources and sinks for DOP
 
     return - dissolved_organic_phosphate_remin(γ, D) +
              (1 - α) * net_community_production(μᵖ, kᴵ, kᴾ, kᴺ, kᶠ, I, P, N, F)
-
 end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Adding some fundamental processes to our simple ocean carbon cycle model:

1.  Iron is complexed by organic ligands according to an equilibrium reaction (e.g. Parekh et al., [2005](https://agupubs.onlinelibrary.wiley.com/doi/10.1029/2004GB002280); [2006](https://agupubs.onlinelibrary.wiley.com/doi/full/10.1029/2005GL025098))
2. Sinking organic particles are remineralized according to a prescribed profile shape, such as a power law or exponential (e.g. [Cael & Bisson, 2018](https://www.frontiersin.org/articles/10.3389/fmars.2018.00395/full); [Lauderdale & Cael, 2021](https://agupubs.onlinelibrary.wiley.com/doi/full/10.1029/2020GL091746)) 


## To-do
- [ ] introduce a simpler 2-D example
- [ ] check it runs correctly/efficiently
