### PR TITLE
Accessible functions and +ve values in `CAN`

### DIFF
--- a/src/carbon_alkalinity_nutrients.jl
+++ b/src/carbon_alkalinity_nutrients.jl
@@ -226,7 +226,7 @@ equation in terms of ligand concentration and stability coefficient. Ligand-comp
                                  ligand_stability_coefficient) 
     kˢᶜᵃᵛ = iron_scavenging_rate
     F     = iron_concentration
-    Lₜ     = ligand_concentration
+    L     = ligand_concentration
     β     = ligand_stability_coefficient
 
     # solve for the equilibrium free iron concentration
@@ -236,8 +236,8 @@ equation in terms of ligand concentration and stability coefficient. Ligand-comp
        # --> R₁(Feᶠʳᵉᵉ)² + R₂ Feᶠʳᵉᵉ + R₃ = 0
        β⁻¹ = 1/β
        R₁  = 1
-       R₂  = (Lₜ + β⁻¹ - Fₜ) 
-       R₃  = -(Fₜ * β⁻¹) 
+       R₂  = (L + β⁻¹ - F) 
+       R₃  = -(F * β⁻¹) 
 
        # simple quadratic solution for roots
        discriminant = sqrt( R₂*R₂ - ( 4*R₁*R₃ ))

--- a/src/carbon_alkalinity_nutrients.jl
+++ b/src/carbon_alkalinity_nutrients.jl
@@ -387,7 +387,7 @@ Tracer sources and sinks for dissolved iron (FeT)
     kᴾ = bgc.nitrate_half_saturation
     kᶠ = bgc.iron_half_saturation
     kᴵ = bgc.PAR_half_saturation
-    I  = bgc.incident_PAR
+    I₀ = bgc.incident_PAR
     λ  = bgc.PAR_attenuation_scale
     γ  = bgc.dissolved_organic_phosphate_remin_timescale
     α  = bgc.fraction_of_particulate_export

--- a/src/carbon_alkalinity_nutrients.jl
+++ b/src/carbon_alkalinity_nutrients.jl
@@ -190,7 +190,9 @@ end
     Fₗᵢₘ = F / (F + kᶠ)
 
     # return the net community production
-    return μᵖ * Lₗᵢₘ * min(Pₗᵢₘ, Nₗᵢₘ, Fₗᵢₘ)
+    return max(0,
+        μᵖ * Lₗᵢₘ * min(Pₗᵢₘ, Nₗᵢₘ, Fₗᵢₘ)
+    )
 end
 
 """
@@ -200,7 +202,7 @@ Calculate the remineralization of dissolved organic phosphate.
 """
 @inline dissolved_organic_phosphate_remin(remineralization_rate, 
                                           dissolved_organic_phosphorus_concentration) = 
-        remineralization_rate * dissolved_organic_phosphorus_concentration
+        max(0, remineralization_rate * dissolved_organic_phosphorus_concentration)
 
 # Martin Curve
 @inline particulate_organic_phosphate_remin() = 0.0

--- a/src/carbon_alkalinity_nutrients.jl
+++ b/src/carbon_alkalinity_nutrients.jl
@@ -225,19 +225,19 @@ equation in terms of ligand concentration and stability coefficient. Ligand-comp
                                  ligand_concentration, 
                                  ligand_stability_coefficient) 
     kˢᶜᵃᵛ = iron_scavenging_rate
-    F     = iron_concentration
-    L     = ligand_concentration
+    Fe    = iron_concentration
+    Lᶠᵉ   = ligand_concentration
     β     = ligand_stability_coefficient
 
     # solve for the equilibrium free iron concentration
        # β = FeL / (Feᶠʳᵉᵉ * Lᶠʳᵉᵉ)
-       # Lₜ = FeL + Lᶠʳᵉᵉ
+       # Lᶠᵉ = FeL + Lᶠʳᵉᵉ
        # Fₜ = FeL + Feᶠʳᵉᵉ
        # --> R₁(Feᶠʳᵉᵉ)² + R₂ Feᶠʳᵉᵉ + R₃ = 0
        β⁻¹ = 1/β
        R₁  = 1
-       R₂  = (L + β⁻¹ - F) 
-       R₃  = -(F * β⁻¹) 
+       R₂  =  (Lᶠᵉ + β⁻¹ - Fe) 
+       R₃  = -(Fe * β⁻¹) 
 
        # simple quadratic solution for roots
        discriminant = sqrt( R₂*R₂ - ( 4*R₁*R₃ ))
@@ -417,7 +417,7 @@ Tracer sources and sinks for dissolved iron (FeT)
     Rᶜᴼ = bgc.stoichoimetric_ratio_carbon_to_oxygen      
     Rᶜᶠ = bgc.stoichoimetric_ratio_carbon_to_iron
     Rᶠᴾ = bgc.stoichoimetric_ratio_iron_to_phosphate
-    Lₜ     = bgc.ligand_concentration
+    Lᶠᵉ   = bgc.ligand_concentration
     β     = bgc.ligand_stability_coefficient
     kˢᶜᵃᵛ = bgc.iron_scavenging_rate
 
@@ -436,7 +436,7 @@ Tracer sources and sinks for dissolved iron (FeT)
                   particulate_organic_phosphate_remin()
                  ) + 
                  iron_sources() -
-                 iron_scavenging(kˢᶜᵃᵛ, F, Lₜ, β)
+                 iron_scavenging(kˢᶜᵃᵛ, F, Lᶠᵉ, β)
 end
 
 

--- a/src/carbon_alkalinity_nutrients.jl
+++ b/src/carbon_alkalinity_nutrients.jl
@@ -38,7 +38,7 @@ end
                                 phosphate_half_saturation                   = 1e-7 * reference_density,
                                 nitrate_half_saturation                     = 1.6e-6 * reference_density,
                                 iron_half_saturation                        = 1e-10 * reference_density,
-                                incident_PAR                                = 700,
+                                incident_PAR                                = 700.0,
                                 PAR_half_saturation                         = 10.0,
                                 PAR_attenuation_scale                       = 25.0,
                                 fraction_of_particulate_export              = 0.33
@@ -88,7 +88,7 @@ function CarbonAlkalinityNutrients(; reference_density = 1024,
                                    phosphate_half_saturation                  = 1e-7 * reference_density, # mol P m⁻³
                                    nitrate_half_saturation                    = 1.6e-6 * reference_density, # mol N m⁻³
                                    iron_half_saturation                       = 1e-10 * reference_density, # mol Fe m⁻³
-                                   incident_PAR                               = 700, # W m⁻²
+                                   incident_PAR                               = 700.0, # W m⁻²
                                    PAR_half_saturation                        = 10.0,  # W m⁻²
                                    PAR_attenuation_scale                      = 25.0,  # m
                                    fraction_of_particulate_export             = 0.33,

--- a/src/carbon_alkalinity_nutrients.jl
+++ b/src/carbon_alkalinity_nutrients.jl
@@ -220,11 +220,14 @@ Calculate the remineralization of dissolved organic phosphate.
 Calculate the scavenging loss of iron. Iron scavenging depends on free iron, which involves solving a quadratic 
 equation in terms of ligand concentration and stability coefficient. Ligand-complexed iron is safe from being scavenged.
 """
-@inline function iron_scavenging(iron_scavenging_rate, iron_concentration, ligand_concentration, ligand_stability_coefficient) 
-    kˢᶜᵃᵛ=iron_scavenging_rate
-    F    =iron_concentration
-    Lₜ    =ligand_concentration
-    β    =ligand_stability_coefficient
+@inline function iron_scavenging(iron_scavenging_rate, 
+                                 iron_concentration, 
+                                 ligand_concentration, 
+                                 ligand_stability_coefficient) 
+    kˢᶜᵃᵛ = iron_scavenging_rate
+    F     = iron_concentration
+    Lₜ     = ligand_concentration
+    β     = ligand_stability_coefficient
 
     # solve for the equilibrium free iron concentration
        # β = FeL / (Feᶠʳᵉᵉ * Lᶠʳᵉᵉ)
@@ -237,7 +240,7 @@ equation in terms of ligand concentration and stability coefficient. Ligand-comp
        R₃  = -(Fₜ * β⁻¹) 
 
        # simple quadratic solution for roots
-       discriminant = ( R₂*R₂ - ( 4*R₁*R₃ ))^(1/2)
+       discriminant = sqrt( R₂*R₂ - ( 4*R₁*R₃ ))
 
        # directly solve for the free iron concentration
        Feᶠʳᵉᵉ = (-R₂ + discriminant) / (2*R₁) 
@@ -427,12 +430,13 @@ Tracer sources and sinks for dissolved iron (FeT)
     F = @inbounds fields.Fe[i, j, k]
     D = @inbounds fields.DOP[i, j, k]
 
-    return (Rᶠᴾ * (
+    return Rᶠᴾ * (
                 - net_community_production(μᵖ, kᴵ, kᴾ, kᴺ, kᶠ, I, P, N, F) +
-                + dissolved_organic_phosphate_remin(γ, D)) 
-           #    + particulate_organic_phosphate_remin()) +
-           #    + iron_sources()
-                - iron_scavenging(kˢᶜᵃᵛ, F, Lₜ, β)
+                  dissolved_organic_phosphate_remin(γ, D) + 
+                  particulate_organic_phosphate_remin()
+                 ) + 
+                 iron_sources() -
+                 iron_scavenging(kˢᶜᵃᵛ, F, Lₜ, β)
 end
 
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->

1. Make `CAN` code more readable (english parameter names in functions).
2. Ensure some functions only return positive values (i.e `net_community_production` and `dissolved_organic_phosphate_remin`).

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
